### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/123brano/9956e296-a518-43b5-9875-4704dcfafea3/019f4e9e-d92d-435d-8e68-65092c0b5bfc/_apis/work/boardbadge/adf58ad4-b266-494c-936a-4c784da2190f)](https://dev.azure.com/123brano/9956e296-a518-43b5-9875-4704dcfafea3/_boards/board/t/019f4e9e-d92d-435d-8e68-65092c0b5bfc/Microsoft.RequirementCategory)
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#4](https://dev.azure.com/123brano/9956e296-a518-43b5-9875-4704dcfafea3/_workitems/edit/4). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.